### PR TITLE
refactor(ci): add logic for checking canary upcoming release on PR merge

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,7 +24,10 @@ jobs:
       version: ${{ steps.canary-release-version.outputs.version }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4   
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history
+          ref: ${{ github.head_ref || github.ref_name }}  # Properly checkout the PR branch or main branch
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -7,7 +7,7 @@ on:
         description: "Dry Run Mode"
         type: boolean
         default: false
-  workflow_call:
+  workflow_call: # This workflow can be called from other workflows, specifically for PR check for upcoming release on merged PR
     inputs:
       dryRun:
         description: "Dry Run Mode for called workflows"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -7,6 +7,12 @@ on:
         description: "Dry Run Mode"
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      dryRun:
+        description: "Dry Run Mode for called workflows"
+        type: boolean
+        default: true
   push:
     branches: [main]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         run: bun install
 
       - name: Run linters
-        run: bun test # TBD: Replace with the actual command to run linters after creating linting repo
+        run: bun test # TBD: Replace with the actual command to run linters after creating linting repo.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - labeled
       - unlabeled
+      - ready_for_review
 
 jobs:
   check-pullrequest-label:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: "[PR] Semantic Pull Request"
+name: "[PR] Validate Title, Labels and Registries"
 on:
   pull_request:
     types:
@@ -17,7 +17,7 @@ jobs:
       - name: Platform label
         uses: agilepathway/label-checker@v1.6.65
         with:
-          any_of: ci,config,deps,npm,jsr,github-packages
+          any_of: ci,config,deps,npm,jsr,github-pkg
           none_of: "@:"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -37,4 +37,15 @@ jobs:
             deps
             npm
             jsr
-            github-packages
+            github-pkg
+
+  check-pullrequest-canary-release:
+    name: Check for Canary Release on merge
+    needs: [check-pullrequest-label, check-pullrequest-title]
+    uses: ./.github/workflows/canary.yml
+    with:
+      dryRun: true
+    permissions:
+      contents: read
+      packages: write
+      id-token: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,6 +42,7 @@ jobs:
   check-pullrequest-canary-release:
     name: Check for Canary Release on merge
     needs: [check-pullrequest-label, check-pullrequest-title]
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/canary.yml
     with:
       dryRun: true


### PR DESCRIPTION
## Description

Modify Canary workflow to check on PR status of canary distribution on PR merge


